### PR TITLE
Better removal

### DIFF
--- a/Project Files/OrderedSet/MasterViewController.swift
+++ b/Project Files/OrderedSet/MasterViewController.swift
@@ -38,7 +38,7 @@ class MasterViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath) as UITableViewCell
+        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath) as! UITableViewCell
 
         let object = objects[indexPath.row] as NSDate
         cell.textLabel!.text = object.description

--- a/Project Files/OrderedSetTests/OrderedSet_Tests.swift
+++ b/Project Files/OrderedSetTests/OrderedSet_Tests.swift
@@ -133,19 +133,22 @@ class OrderedSet_Tests: XCTestCase {
     
     func testRemove_whenObjectExists_reducesCount() {
         var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        subject.remove("Two")
+        var removedObject:OrderedSet.Index? = subject.remove("Two")
+        XCTAssert(removedObject == 1)
         XCTAssertEqual(subject.count, 2)
     }
     
     func testRemove_whenObjectDoesntExist_doesntChangeCount() {
         var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        subject.remove("Twoz")
+        var removedObject:OrderedSet.Index? = subject.remove("Twoz")
+        XCTAssertNil(removedObject)
         XCTAssertEqual(subject.count, 3)
     }
     
     func testRemove_whenObjectIsNotLast_updatesOrdering() {
         var subject = OrderedSet<String>(sequence: ["One", "Two", "Three", "Four"])
-        subject.remove("Two")
+        var removedObject:OrderedSet.Index? = subject.remove("Two")
+        XCTAssert(removedObject == 1)
         XCTAssert(subject[0] == "One")
         XCTAssert(subject[1] == "Three")
         XCTAssert(subject[2] == "Four")
@@ -164,7 +167,8 @@ class OrderedSet_Tests: XCTestCase {
     
     func testRemoveObjectAtIndex_removesTheObjectAtIndex() {
         var subject = OrderedSet<String>(sequence: ["One", "Two", "Three", "Four"])
-        subject.removeObjectAtIndex(1)
+        var removedObject:String? = subject.removeObjectAtIndex(1)
+        XCTAssert(removedObject == "Two")
         let expected: OrderedSet<String> = ["One", "Three", "Four"]
         XCTAssertEqual(subject, expected)
     }

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -143,9 +143,12 @@ public struct OrderedSet<T: Hashable> {
         objects will be shifted down one position.
     
         :param:     object  The object to be removed.
-    */
-    mutating public func remove(object: T) {
+         :return:    Index if OrderSet contains object, else nil.
+ */
+    mutating public func remove(object: T) -> Index?{
+        var returnIndex: Index?
         if let index = contents[object] {
+            returnIndex = index
             contents[object] = nil
             sequencedContents[index].dealloc(1)
             sequencedContents.removeAtIndex(index)
@@ -158,6 +161,7 @@ public struct OrderedSet<T: Hashable> {
                 contents[object] = i - 1
             }
         }
+        return returnIndex
     }
     
     /**
@@ -176,15 +180,18 @@ public struct OrderedSet<T: Hashable> {
         Removes an object at a given index.
 
         This method will cause a fatal error if you attempt to move an object to an index that is out of bounds.
-        
+    
         :param:     index       The index of the object to be removed.
-    */
-    mutating public func removeObjectAtIndex(index: Index) {
+        :return:    Object that was removed.
+*/
+    mutating public func removeObjectAtIndex(index: Index) ->T{
         if index < 0 || index >= count {
             fatalError("Attempting to remove an object at an index that does not exist")
         }
         
-        remove(sequencedContents[index].memory)
+        let returnObject = sequencedContents[index].memory
+        remove(returnObject)
+        return returnObject
     }
     
     /**


### PR DESCRIPTION
# Better Removal
### remove

`func remove()` is now

``` swift
func remove(object: T) -> Index?
```

User now gets the index of object that is being removed. If removal was not successful nil is returned.
It is backward compatible change as the returned object can be discarded by not collection in a variable
### removeObjectAtIndex

`func removeObjectAtIndex(index: Index)` is now

``` swift
func removeObjectAtIndex(index: Index) ->T
```

User now gets the object that is being removed at index. It is also backward compatible for same reason
Note: Native swift Array and Set mostly return something when removing objects
