### PR TITLE
Upgrade to Swift 3

### DIFF
--- a/OrderedSet.podspec
+++ b/OrderedSet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OrderedSet"
-  s.version      = "1.0.0"
+  s.version      = "2.0.0"
   s.summary      = "A Swift implementation of an OrderedSet."
 
   s.description  = <<-DESC
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
 
-  s.source       = { :git => "https://github.com/Weebly/OrderedSet.git", :tag => "v1.0.0" }
+  s.source       = { :git => "https://github.com/Weebly/OrderedSet.git", :tag => "v2.0.0" }
 
   s.requires_arc = true
 

--- a/Project Files/OrderedSet.xcodeproj/project.pbxproj
+++ b/Project Files/OrderedSet.xcodeproj/project.pbxproj
@@ -160,14 +160,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Weebly;
 				TargetAttributes = {
 					1ABC4FB61A5C966200DC4F4D = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 					1ABC4FCD1A5C966200DC4F4D = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 1ABC4FB61A5C966200DC4F4D;
 					};
 				};
@@ -273,15 +275,19 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -315,8 +321,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -324,6 +332,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -333,6 +342,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -343,7 +353,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = OrderedSet/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Weebly.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -353,7 +365,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = OrderedSet/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Weebly.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -371,7 +385,9 @@
 				);
 				INFOPLIST_FILE = OrderedSetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Weebly.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OrderedSet.app/OrderedSet";
 			};
 			name = Debug;
@@ -386,7 +402,9 @@
 				);
 				INFOPLIST_FILE = OrderedSetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Weebly.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OrderedSet.app/OrderedSet";
 			};
 			name = Release;

--- a/Project Files/OrderedSet/AppDelegate.swift
+++ b/Project Files/OrderedSet/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Project Files/OrderedSet/Info.plist
+++ b/Project Files/OrderedSet/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.Weebly.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Project Files/OrderedSet/MasterViewController.swift
+++ b/Project Files/OrderedSet/MasterViewController.swift
@@ -10,50 +10,50 @@ import UIKit
 
 class MasterViewController: UITableViewController {
 
-    var objects = OrderedSet<NSDate>()
+    var objects = OrderedSet<Date>()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
-        self.navigationItem.leftBarButtonItem = self.editButtonItem()
+        self.navigationItem.leftBarButtonItem = self.editButtonItem
 
-        let addButton = UIBarButtonItem(barButtonSystemItem: .Add, target: self, action: #selector(MasterViewController.insertNewObject(_:)))
+        let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(MasterViewController.insertNewObject(_:)))
         self.navigationItem.rightBarButtonItem = addButton
     }
 
-    func insertNewObject(sender: AnyObject) {
-        objects.insertObject(NSDate(), atIndex: 0)
-        let indexPath = NSIndexPath(forRow: 0, inSection: 0)
-        self.tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+    func insertNewObject(_ sender: AnyObject) {
+        objects.insert(Date(), at: 0)
+        let indexPath = IndexPath(row: 0, section: 0)
+        self.tableView.insertRows(at: [indexPath], with: .automatic)
     }
 
     // MARK: - Table View
 
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
 
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return objects.count
     }
 
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath) as UITableViewCell
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as UITableViewCell
 
-        let object = objects[indexPath.row] as NSDate
+        let object = objects[(indexPath as NSIndexPath).row] as Date
         cell.textLabel!.text = object.description
         return cell
     }
 
-    override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         // Return false if you do not want the specified item to be editable.
         return true
     }
 
-    override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
-        if editingStyle == .Delete {
-            objects.removeObjectAtIndex(indexPath.row)
-            tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            objects.removeObject(at: indexPath.row)
+            tableView.deleteRows(at: [indexPath], with: .fade)
         }
     }
 }

--- a/Project Files/OrderedSetTests/Info.plist
+++ b/Project Files/OrderedSetTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.Weebly.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Project Files/OrderedSetTests/OrderedSet_Tests.swift
+++ b/Project Files/OrderedSetTests/OrderedSet_Tests.swift
@@ -303,7 +303,7 @@ class OrderedSet_Tests: XCTestCase {
     
     func testLast_whenEmpty_isNil() {
         let subject = OrderedSet<String>()
-        XCTAssert(subject.first == nil)
+        XCTAssert(subject.last == nil)
     }
     
     func testLast_whenNotEmpty_isFirstElement() {

--- a/Project Files/OrderedSetTests/OrderedSet_Tests.swift
+++ b/Project Files/OrderedSetTests/OrderedSet_Tests.swift
@@ -35,13 +35,13 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Append
     
     func testAppend_increasesCount() {
-        var subject = OrderedSet<String>()
+        let subject = OrderedSet<String>()
         subject.append("Test")
         XCTAssertEqual(subject.count, 1)
     }
 
     func testAppend_withSameObjectTwice_keepsCountAs1() {
-        var subject = OrderedSet<String>()
+        let subject = OrderedSet<String>()
         subject.append("Test")
         subject.append("Test")
         XCTAssertEqual(subject.count, 1)
@@ -50,13 +50,13 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Subscript
     
     func testObjectSubscript_returnsCorrectObject() {
-        var subject = OrderedSet<String>()
+        let subject = OrderedSet<String>()
         subject.append("Test")
         XCTAssert(subject[0] == "Test")
     }
     
     func testSubscriptInsertion_replacesObject() {
-        var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
+        let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
         subject[1] = "wat"
         XCTAssertEqual(subject.count, 3)
         XCTAssert(subject[0] == "One")
@@ -67,7 +67,7 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Contains
 
     func testContains_whenObjectIsContained_isTrue() {
-        var subject = OrderedSet<String>()
+        let subject = OrderedSet<String>()
         subject.append("Test")
         XCTAssertTrue(subject.contains("Test"))
     }
@@ -123,30 +123,30 @@ class OrderedSet_Tests: XCTestCase {
     
     func testIndexOfObject_whenObjectExists_isCorrectIndex() {
         let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        XCTAssert(subject.indexOfObject("Three") == 2)
+        XCTAssert(subject.index(of: "Three") == 2)
     }
     
     func testIndexOfObject_whenObjectDoesntExist_isNil() {
         let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        XCTAssertNil(subject.indexOfObject("Four"))
+        XCTAssertNil(subject.index(of: "Four"))
     }
     
     // MARK: Remove
     
     func testRemove_whenObjectExists_reducesCount() {
-        var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
+        let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
         subject.remove("Two")
         XCTAssertEqual(subject.count, 2)
     }
     
     func testRemove_whenObjectDoesntExist_doesntChangeCount() {
-        var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
+        let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
         subject.remove("Twoz")
         XCTAssertEqual(subject.count, 3)
     }
     
     func testRemove_whenObjectIsNotLast_updatesOrdering() {
-        var subject = OrderedSet<String>(sequence: ["One", "Two", "Three", "Four"])
+        let subject = OrderedSet<String>(sequence: ["One", "Two", "Three", "Four"])
         subject.remove("Two")
         XCTAssert(subject[0] == "One")
         XCTAssert(subject[1] == "Three")
@@ -156,8 +156,8 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Remove Objects
     
     func testRemoveObjects_removesPassedInObjects() {
-        var subject = OrderedSet<String>(sequence: ["One", "Two", "Three", "Four"])
-        subject.removeObjects(["Two", "Four"])
+        let subject = OrderedSet<String>(sequence: ["One", "Two", "Three", "Four"])
+        subject.remove(["Two", "Four"])
         let expected: OrderedSet<String> = ["One", "Three"]
         XCTAssertEqual(subject, expected)
     }
@@ -165,8 +165,8 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Remove Object At Index
     
     func testRemoveObjectAtIndex_removesTheObjectAtIndex() {
-        var subject = OrderedSet<String>(sequence: ["One", "Two", "Three", "Four"])
-        subject.removeObjectAtIndex(1)
+        let subject = OrderedSet<String>(sequence: ["One", "Two", "Three", "Four"])
+        subject.removeObject(at: 1)
         let expected: OrderedSet<String> = ["One", "Three", "Four"]
         XCTAssertEqual(subject, expected)
     }
@@ -174,7 +174,7 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Remove All Objects
     
     func testRemoveAllObjects_removesAllObjects() {
-        var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
+        let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
         subject.removeAllObjects()
         XCTAssertEqual(subject.count, 0)
     }
@@ -183,29 +183,29 @@ class OrderedSet_Tests: XCTestCase {
     
     func testIntersectsSequence_withoutIntersection_isFalse() {
         let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        XCTAssertFalse(subject.intersectsSequence(["Four"]))
+        XCTAssertFalse(subject.intersects(["Four"]))
     }
     
     func testIntersectsSequence_withIntersection_isTrue() {
         let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        XCTAssertTrue(subject.intersectsSequence(["Two"]))
+        XCTAssertTrue(subject.intersects(["Two"]))
     }
     
     // MARK: Is Subset Of Sequence
     
     func testIsSubsetOfSequence_whenIsSubset_isTrue() {
         let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        XCTAssertTrue(subject.isSubsetOfSequence(["Three", "Two", "One"]))
+        XCTAssertTrue(subject.isSubset(of: ["Three", "Two", "One"]))
     }
     
     func testIsSubsetOfSequence_whenIsSubset_andContainsDuplicates_isTrue() {
         let subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        XCTAssertTrue(subject.isSubsetOfSequence(["Three", "Two", "One", "Three"]))
+        XCTAssertTrue(subject.isSubset(of: ["Three", "Two", "One", "Three"]))
     }
     
     func testIsSubsetOfSequence_whenIsNotSubset_isFalse() {
         let subject = OrderedSet<String>(sequence: ["One", "Two"])
-        XCTAssertTrue(subject.isSubsetOfSequence(["Three", "Two", "One"]))
+        XCTAssertTrue(subject.isSubset(of: ["Three", "Two", "One"]))
     }
     
     // MARK: Concatenation
@@ -303,7 +303,7 @@ class OrderedSet_Tests: XCTestCase {
     
     func testLast_whenEmpty_isNil() {
         let subject = OrderedSet<String>()
-        XCTAssert(subject.last == nil)
+        XCTAssert(subject.first == nil)
     }
     
     func testLast_whenNotEmpty_isFirstElement() {
@@ -314,15 +314,15 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: - Swap Object
     
     func testSwapObject_whenBothObjectsExist_swapsBothObjects() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.swapObject("One", withObject: "Three")
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.swapObject("One", with: "Three")
         let expected: OrderedSet<String> = ["Three", "Two", "One"]
         XCTAssertEqual(subject, expected)
     }
     
     func testSwapObject_whenOneObjectsExist_doesntChangeSet() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.swapObject("One", withObject: "Four")
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.swapObject("One", with: "Four")
         let expected: OrderedSet<String> = ["One", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
@@ -330,78 +330,78 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Move Object to Index
     
     func testMoveObjectToIndex_whenObjectExists_whenMovingAmongEntireSet_movesObjectUp_andShiftsOthersDown() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
         subject.moveObject("One", toIndex: 2)
         let expected: OrderedSet<String> = ["Two", "Three", "One"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectToIndex_whenObjectExists_whenMovingAmongEntireSet_movesObjectDown_andShiftsOthersUp() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
         subject.moveObject("Three", toIndex: 0)
         let expected: OrderedSet<String> = ["Three", "One", "Two"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectToIndex_whenObjectExists_whenMovingAmongSubsetOfSet_movesObjectUp_andShiftsTraversedObjectsDown() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
+        let subject: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
         subject.moveObject("Four", toIndex: 1)
         let expected: OrderedSet<String> = ["One", "Four", "Two", "Three", "Five"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectToIndex_whenObjectExists_whenMovingAmongSubsetOfSet_movesObjectDown_andShiftsTraversedObjectsUp() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
+        let subject: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
         subject.moveObject("Two", toIndex: 3)
         let expected: OrderedSet<String> = ["One", "Three", "Four", "Two", "Five"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectToIndex_whenObjectDoesntExist_isNoop() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
         subject.moveObject("Four", toIndex: 0)
         let expected: OrderedSet<String> = ["One", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectToIndex_whenObjectIsSameIndex_isNoop() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
         subject.moveObject("One", toIndex: 0)
         let expected: OrderedSet<String> = ["One", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectAtIndex_whenObjectExists_whenMovingAmongEntireSet_movesObjectUp_andShiftsOthersDown() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.moveObjectAtIndex(0, toIndex: 2)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.moveObject(at: 0, to: 2)
         let expected: OrderedSet<String> = ["Two", "Three", "One"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectAtIndex_whenObjectExists_whenMovingAmongEntireSet_movesObjectDown_andShiftsOthersUp() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.moveObjectAtIndex(2, toIndex: 0)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.moveObject(at: 2, to: 0)
         let expected: OrderedSet<String> = ["Three", "One", "Two"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectAtIndex_whenObjectExists_whenMovingAmongSubsetOfSet_movesObjectUp_andShiftsTraversedObjectsDown() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
-        subject.moveObjectAtIndex(3, toIndex: 1)
+        let subject: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
+        subject.moveObject(at: 3, to: 1)
         let expected: OrderedSet<String> = ["One", "Four", "Two", "Three", "Five"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectAtIndex_whenObjectExists_whenMovingAmongSubsetOfSet_movesObjectDown_andShiftsTraversedObjectsUp() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
-        subject.moveObjectAtIndex(1, toIndex: 3)
+        let subject: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
+        subject.moveObject(at: 1, to: 3)
         let expected: OrderedSet<String> = ["One", "Three", "Four", "Two", "Five"]
         XCTAssertEqual(subject, expected)
     }
     
     func testMoveObjectAtIndex_whenSameIndexes_isNoop() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.moveObjectAtIndex(0, toIndex: 0)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.moveObject(at: 0, to: 0)
         let expected: OrderedSet<String> = ["One", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
@@ -409,22 +409,22 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Insert Object at Index
     
     func testInsertObjectAtIndex_whenObjectDoesntExist_insertsObjectAtCorrectSpot() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.insertObject("Zero", atIndex: 0)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.insert("Zero", at: 0)
         let expected: OrderedSet<String> = ["Zero", "One", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
     
     func testInsertObjectAtIndex_whenObjectDoesExist_isNoop() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.insertObject("Two", atIndex: 0)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.insert("Two", at: 0)
         let expected: OrderedSet<String> = ["One", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
     
     func testInsertObjectAtIndex_canInsertObjectAtTail() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.insertObject("Four", atIndex: 3)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.insert("Four", at: 3)
         let expected: OrderedSet<String> = ["One", "Two", "Three", "Four"]
         XCTAssertEqual(subject, expected)
     }
@@ -432,29 +432,29 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Insert Objects at Index
     
     func testInsertObjectsAtIndex_whenObjectsDontExist_insertsObjectsAtCorrectSpot() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.insertObjects(["Foo", "Bar"], atIndex: 1)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.insert(["Foo", "Bar"], at: 1)
         let expected: OrderedSet<String> = ["One", "Foo", "Bar", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
     
     func testInsertObjectsAtIndex_whenSomeObjectsExist_insertsOnlyNonExistingObjectsAtCorrectSpot() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.insertObjects(["Foo", "Three"], atIndex: 1)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.insert(["Foo", "Three"], at: 1)
         let expected: OrderedSet<String> = ["One", "Foo", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
     
     func testInsertObjectsAtIndex_whenRepeatedObjectsAreInserted_insertsOnlyOne() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.insertObjects(["Foo", "Foo"], atIndex: 1)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.insert(["Foo", "Foo"], at: 1)
         let expected: OrderedSet<String> = ["One", "Foo", "Two", "Three"]
         XCTAssertEqual(subject, expected)
     }
     
     func testInsertObjectsAtIndex_canInsertObjectAtTail() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.insertObjects(["Four", "Five"], atIndex: 3)
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.insert(["Four", "Five"], at: 3)
         let expected: OrderedSet<String> = ["One", "Two", "Three", "Four", "Five"]
         XCTAssertEqual(subject, expected)
     }
@@ -462,22 +462,22 @@ class OrderedSet_Tests: XCTestCase {
     // MARK: Append Objects
     
     func testAppendObjects_whenObjectsDontExist_appendsAllObjects() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.appendObjects(["Foo", "Bar"])
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.append(contentsOf: ["Foo", "Bar"])
         let expected: OrderedSet<String> = ["One", "Two", "Three", "Foo", "Bar"]
         XCTAssertEqual(subject, expected)
     }
     
     func testAppendObjects_whenSomeObjectsExist_appendsOnlyNonExistingObjects() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.appendObjects(["Foo", "Two"])
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.append(contentsOf: ["Foo", "Two"])
         let expected: OrderedSet<String> = ["One", "Two", "Three", "Foo"]
         XCTAssertEqual(subject, expected)
     }
     
     func testAppendObjects_whenRepeatedObjectsAreAppended_appendsOnlyOne() {
-        var subject: OrderedSet<String> = ["One", "Two", "Three"]
-        subject.appendObjects(["Foo", "Foo"])
+        let subject: OrderedSet<String> = ["One", "Two", "Three"]
+        subject.append(contentsOf: ["Foo", "Foo"])
         let expected: OrderedSet<String> = ["One", "Two", "Three", "Foo"]
         XCTAssertEqual(subject, expected)
     }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ set.append(1)
 set.contains(1) // => true
 set[0] = 2
 set[0] // => 2
-set.insertObject(3, atIndex: 0)
+set.insert(3, at: 0)
 set // => [3, 2]
 set = [1,2,3] // OrderedSet's support array literals
 set // => [1, 2, 3]
@@ -29,7 +29,7 @@ Be sure to check out the unit tests to see all the different ways to interact wi
 OrderedSet is a single Swift file in the Sources directory. You can copy that file into your project, or use CocoaPods by adding the following line to your Podfile:
 
 ```ruby
-pod 'OrderedSet', '1.0'
+pod 'OrderedSet', '2.0'
 ```
 
 And then add the following import where you want to use OrderedSet:

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -7,13 +7,13 @@
 //
 
 /// An ordered, unique collection of objects.
-public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
-    private var contents = [T: Index]() // Needs to have a value of Index instead of Void for fast removals
-    private var sequencedContents = Array<UnsafeMutablePointer<T>>()
+open class OrderedSet<T: Hashable> {
+    fileprivate var contents = [T: Index]() // Needs to have a value of Index instead of Void for fast removals
+    fileprivate var sequencedContents = Array<UnsafeMutablePointer<T>>()
     
     /**
      Inititalizes an empty ordered set.
-     :return: An empty ordered set.
+     - returns:     An empty ordered set.
      */
     public init() { }
     
@@ -26,42 +26,40 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
      of sequence.
      If an object appears more than once in the sequence it will only appear
      once in the ordered set, at the position of its first occurance.
-     :param: sequence The sequence to initialize the ordered set with.
-     :return: An initialized ordered set with the contents of sequence.
+     - parameter    sequence:   The sequence to initialize the ordered set with.
+     - returns:                 An initialized ordered set with the contents of sequence.
      */
-    public init<S: SequenceType where S.Generator.Element == T>(sequence: S) {
+    public init<S: Sequence>(sequence: S) where S.Iterator.Element == T {
         for object in sequence {
             if contents[object] == nil {
                 contents[object] = contents.count
                 
-                let pointer = UnsafeMutablePointer<T>.alloc(1)
-                pointer.initialize(object)
+                let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+                pointer.initialize(to: object)
                 sequencedContents.append(pointer)
             }
         }
     }
-    
-    // FIXME: putting this in an ArrayLiteralConvertible extension is now crashing the compiler, move it back when fixed
+
     public required init(arrayLiteral elements: T...) {
         for object in elements {
             if contents[object] == nil {
                 contents[object] = contents.count
                 
-                let pointer = UnsafeMutablePointer<T>.alloc(1)
-                pointer.initialize(object)
+                let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+                pointer.initialize(to: object)
                 sequencedContents.append(pointer)
             }
         }
     }
     
-    
     /**
      Locate the index of an object in the ordered set.
      It is preferable to use this method over the global find() for performance reasons.
-     :param:     object      The object to find the index for.
-     :return:    The index of the object, or nil if the object is not in the ordered set.
+     - parameter    object: The object to find the index for.
+     - returns:             The index of the object, or nil if the object is not in the ordered set.
      */
-    public func indexOfObject(object: T) -> Index? {
+    public func index(of object: T) -> Index? {
         if let index = contents[object] {
             return index
         }
@@ -71,27 +69,27 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
     
     /**
      Appends an object to the end of the ordered set.
-     :param:     object  The object to be appended.
+     - parameter    object: The object to be appended.
      */
-    public func append(object: T) {
+    public func append(_ object: T) {
         
-        if let lastIndex = indexOfObject(object) {
+        if let lastIndex = index(of: object) {
             remove(object)
-            insertObject(object, atIndex: lastIndex)
+            insert(object, at: lastIndex)
         } else {
             contents[object] = contents.count
-            let pointer = UnsafeMutablePointer<T>.alloc(1)
-            pointer.initialize(object)
+            let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+            pointer.initialize(to: object)
             sequencedContents.append(pointer)
         }
     }
     
     /**
      Appends a sequence of objects to the end of the ordered set.
-     :param:     objects  The objects to be appended.
+     - parameter    sequence:   The sequence of objects to be appended.
      */
-    public func appendObjects<S: SequenceType where S.Generator.Element == T>(objects: S) {
-        var gen = objects.generate()
+    public func append<S: Sequence>(contentsOf sequence: S) where S.Iterator.Element == T {
+        var gen = sequence.makeIterator()
         while let object: T = gen.next() {
             append(object)
         }
@@ -102,13 +100,13 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
      If the object exists in the ordered set, it will be removed.
      If it is not the last object in the ordered set, subsequent
      objects will be shifted down one position.
-     :param:     object  The object to be removed.
+     - parameter    object: The object to be removed.
      */
-    public func remove(object: T) {
+    public func remove(_ object: T) {
         if let index = contents[object] {
             contents[object] = nil
-            sequencedContents[index].dealloc(1)
-            sequencedContents.removeAtIndex(index)
+            sequencedContents[index].deallocate(capacity: 1)
+            sequencedContents.remove(at: index)
             
             for (object, i) in contents {
                 if i < index {
@@ -122,10 +120,10 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
     
     /**
      Removes the given objects from the ordered set.
-     :param:     objects     The objects to be removed.
+     - parameter    objects:    The objects to be removed.
      */
-    public func removeObjects<S: SequenceType where S.Generator.Element == T>(objects: S) {
-        var gen = objects.generate()
+    public func remove<S: Sequence>(_ objects: S) where S.Iterator.Element == T {
+        var gen = objects.makeIterator()
         while let object: T = gen.next() {
             remove(object)
         }
@@ -134,14 +132,14 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
     /**
      Removes an object at a given index.
      This method will cause a fatal error if you attempt to move an object to an index that is out of bounds.
-     :param:     index       The index of the object to be removed.
+     - parameter    index:  The index of the object to be removed.
      */
-    public func removeObjectAtIndex(index: Index) {
+    public func removeObject(at index: Index) {
         if index < 0 || index >= count {
             fatalError("Attempting to remove an object at an index that does not exist")
         }
         
-        remove(sequencedContents[index].memory)
+        remove(sequencedContents[index].pointee)
     }
     
     /**
@@ -151,7 +149,7 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
         contents.removeAll()
         
         for sequencedContent in sequencedContents {
-            sequencedContent.dealloc(1)
+            sequencedContent.deallocate(capacity: 1)
         }
         
         sequencedContents.removeAll()
@@ -160,28 +158,28 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
     /**
      Swaps two objects contained within the ordered set.
      Both objects must exist within the set, or the swap will not occur.
-     :param:     first   The first object to be swapped.
-     :param:     second  The second object to be swapped.
+     - parameter    first:  The first object to be swapped.
+     - parameter    second: The second object to be swapped.
      */
-    public func swapObject(first: T, withObject second: T) {
+    public func swapObject(_ first: T, with second: T) {
         if let firstPosition = contents[first] {
             if let secondPosition = contents[second] {
                 contents[first] = secondPosition
                 contents[second] = firstPosition
                 
-                sequencedContents[firstPosition].memory = second
-                sequencedContents[secondPosition].memory = first
+                sequencedContents[firstPosition].pointee = second
+                sequencedContents[secondPosition].pointee = first
             }
         }
     }
     
     /**
      Tests if the ordered set contains any objects within a sequence.
-     :param:     sequence    The sequence to look for the intersection in.
-     :return:    Returns true if the sequence and set contain any equal objects, otherwise false.
+     - parameter    other:  The sequence to look for the intersection in.
+     - returns:             Returns true if the sequence and set contain any equal objects, otherwise false.
      */
-    public func intersectsSequence<S: SequenceType where S.Generator.Element == T>(sequence: S) -> Bool {
-        var gen = sequence.generate()
+    public func intersects<S: Sequence>(_ other: S) -> Bool where S.Iterator.Element == T {
+        var gen = other.makeIterator()
         while let object: T = gen.next() {
             if contains(object) {
                 return true
@@ -193,10 +191,10 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
     
     /**
      Tests if a the ordered set is a subset of another sequence.
-     :param:     sequence    The sequence to check.
-     :return:    true if the sequence contains all objects contained in the receiver, otherwise false.
+     - parameter    sequence:   The sequence to check.
+     - returns:                 true if the sequence contains all objects contained in the receiver, otherwise false.
      */
-    public func isSubsetOfSequence<S: SequenceType where S.Generator.Element == T>(sequence: S) -> Bool {
+    public func isSubset<S: Sequence>(of sequence: S) -> Bool where S.Iterator.Element == T {
         for (object, _) in contents {
             if !sequence.contains(object) {
                 return false
@@ -211,10 +209,10 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
      This method is a no-op if the object doesn't exist in the set or the index is the
      same that the object is currently at.
      This method will cause a fatal error if you attempt to move an object to an index that is out of bounds.
-     :param:     object  The object to be moved
-     :param:     index   The index that the object should be moved to.
+     - parameter    object: The object to be moved
+     - parameter    index:  The index that the object should be moved to.
      */
-    public func moveObject(object: T, toIndex index: Index) {
+    public func moveObject(_ object: T, toIndex index: Index) {
         if index < 0 || index >= count {
             fatalError("Attempting to move an object at an index that does not exist")
         }
@@ -229,18 +227,18 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
             let range = index < position ? index..<position : position..<index
             for (object, i) in contents {
                 // Skip items not within the range of movement
-                if i < range.startIndex || i > range.endIndex || i == position {
+                if i < range.lowerBound || i > range.upperBound || i == position {
                     continue
                 }
                 
                 let originalIndex = contents[object]!
                 let newIndex = i + adjustment
                 
-                let firstObject = sequencedContents[originalIndex].memory
-                let secondObject = sequencedContents[newIndex].memory
+                let firstObject = sequencedContents[originalIndex].pointee
+                let secondObject = sequencedContents[newIndex].pointee
                 
-                sequencedContents[originalIndex].memory = secondObject
-                sequencedContents[newIndex].memory = firstObject
+                sequencedContents[originalIndex].pointee = secondObject
+                sequencedContents[newIndex].pointee = firstObject
                 
                 contents[object] = newIndex
             }
@@ -254,10 +252,10 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
      This method is a no-op if the index is the same that the object is currently at.
      This method will cause a fatal error if you attempt to move an object fro man index that is out of bounds
      or to an index that is out of bounds.
-     :param:     index   The index of the object to be moved.
-     :param:     toIndex   The index that the object should be moved to.
+     -parameter     index:      The index of the object to be moved.
+     -parameter     toIndex:    The index that the object should be moved to.
      */
-    public func moveObjectAtIndex(index: Index, toIndex: Index) {
+    public func moveObject(at index: Index, to toIndex: Index) {
         if ((index < 0 || index >= count) || (toIndex < 0 || toIndex >= count)) {
             fatalError("Attempting to move an object at or to an index that does not exist")
         }
@@ -269,10 +267,10 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
      Inserts an object at a given index, shifting all objects above it up one.
      This method will cause a fatal error if you attempt to insert the object out of bounds.
      If the object already exists in the OrderedSet, this operation is a no-op.
-     :param:     object      The object to be inserted.
-     :param:     atIndex     The index to be inserted at.
+     - parameter    object:     The object to be inserted.
+     - parameter    index:      The index to be inserted at.
      */
-    public func insertObject(object: T, atIndex index: Index) {
+    public func insert(_ object: T, at index: Index) {
         if index > count || index < 0 {
             fatalError("Attempting to insert an object at an index that does not exist")
         }
@@ -284,8 +282,8 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
         // Append our object, then swap them until its at the end.
         append(object)
         
-        for i in (index..<count-1).reverse() {
-            swapObject(self[i], withObject: self[i+1])
+        for i in (index..<count-1).reversed() {
+            swapObject(self[i], with: self[i+1])
         }
     }
     
@@ -294,26 +292,22 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
      This method will cause a fatal error if you attempt to insert the objects out of bounds.
      If an object in objects already exists in the OrderedSet it will not be added. Objects that occur twice
      in the sequence will only be added once.
-     :param:     objects      The objects to be inserted.
-     :param:     atIndex      The index to be inserted at.
+     - parameter    objects:    The objects to be inserted.
+     - parameter    index:      The index to be inserted at.
      */
-    public func insertObjects<S: SequenceType where S.Generator.Element == T>(objects: S, atIndex index: Index) {
+    public func insert<S: Sequence>(_ objects: S, at index: Index) where S.Iterator.Element == T {
         if index > count || index < 0 {
             fatalError("Attempting to insert an object at an index that does not exist")
         }
         
         var addedObjectCount = 0
-        // FIXME: For some reason, Swift gives the error "Cannot convert the expression's type 'S' to type 'S'" with a regular for-in, so this is a hack to fix that.
-        var gen = objects.generate()
-        
-        // This loop will make use of our sequncedContents array to update the contents dictionary's
-        // values. During this loop there will be duplicate values in the dictionary.
-        while let object: T = gen.next() {
+
+        for object in objects {
             if contents[object] == nil {
                 let seqIdx = index + addedObjectCount
-                let element = UnsafeMutablePointer<T>.alloc(1)
-                element.initialize(object)
-                sequencedContents.insert(element, atIndex: seqIdx)
+                let element = UnsafeMutablePointer<T>.allocate(capacity: 1)
+                element.initialize(to: object)
+                sequencedContents.insert(element, at: seqIdx)
                 contents[object] = seqIdx
                 addedObjectCount += 1
             }
@@ -322,14 +316,25 @@ public class OrderedSet<T: Hashable> : ArrayLiteralConvertible {
         // Now we'll remove duplicates and update the shifted objects position in the contents
         // dictionary.
         for i in index + addedObjectCount..<count {
-            contents[sequencedContents[i].memory] = i
+            contents[sequencedContents[i].pointee] = i
         }
     }
 }
 
+extension OrderedSet: ExpressibleByArrayLiteral {
+
+
+
+}
+
 extension OrderedSet where T: Comparable {}
 
-extension OrderedSet: MutableCollectionType {
+extension OrderedSet: MutableCollection {
+
+    public func index(after i: Int) -> Int {
+        return sequencedContents.index(after: i)
+    }
+
     public typealias Index = Int
     
     public var startIndex: Int {
@@ -342,60 +347,78 @@ extension OrderedSet: MutableCollectionType {
     
     public subscript(index: Index) -> T {
         get {
-            return sequencedContents[index].memory
+            return sequencedContents[index].pointee
         }
         
         set {
-            contents[sequencedContents[index].memory] = nil
+            contents[sequencedContents[index].pointee] = nil
             contents[newValue] = index
-            sequencedContents[index].memory = newValue
+            sequencedContents[index].pointee = newValue
         }
     }
 }
 
-extension  OrderedSet: SequenceType {
-    public typealias Generator = OrderedSetGenerator<T>
+extension OrderedSet: BidirectionalCollection {
+
+    public func index(before i: Index) -> Int {
+        return sequencedContents.index(before: i)
+    }
+
+    public subscript(bounds: Range<Int>) -> BidirectionalSlice<OrderedSet<T>> {
+        get {
+            return BidirectionalSlice(base: self, bounds: bounds)
+        }
+        set {
+            for (index, _) in sequencedContents[bounds].enumerated() {
+                self[index] = newValue[index]
+            }
+        }
+    }
+}
+
+extension  OrderedSet: Sequence {
+    public typealias Iterator = OrderedSetGenerator<T>
     
-    public func generate() -> Generator {
+    public func makeIterator() -> Iterator {
         return OrderedSetGenerator(set: self)
     }
 }
 
-public struct OrderedSetGenerator<T: Hashable>: GeneratorType {
+public struct OrderedSetGenerator<T: Hashable>: IteratorProtocol {
     public typealias Element = T
-    private var generator: IndexingGenerator<Array<UnsafeMutablePointer<T>>>
+    fileprivate var generator: IndexingIterator<Array<UnsafeMutablePointer<T>>>
     
     public init(set: OrderedSet<T>) {
-        generator = set.sequencedContents.generate()
+        generator = set.sequencedContents.makeIterator()
     }
     
     public mutating func next() -> Element? {
-        return generator.next()?.memory
+        return generator.next()?.pointee
     }
 }
 
 extension OrderedSetGenerator where T: Comparable {}
 
-public func +<T: Hashable, S: SequenceType where S.Generator.Element == T> (lhs: OrderedSet<T>, rhs: S) -> OrderedSet<T> {
+public func +<T: Hashable, S: Sequence> (lhs: OrderedSet<T>, rhs: S) -> OrderedSet<T> where S.Iterator.Element == T {
     let joinedSet = lhs
-    joinedSet.appendObjects(rhs)
+    joinedSet.append(contentsOf: rhs)
     
     return joinedSet
 }
 
-public func +=<T: Hashable, S: SequenceType where S.Generator.Element == T> (inout lhs: OrderedSet<T>, rhs: S) {
-    lhs.appendObjects(rhs)
+public func +=<T: Hashable, S: Sequence> (lhs: inout OrderedSet<T>, rhs: S) where S.Iterator.Element == T {
+    lhs.append(contentsOf: rhs)
 }
 
-public func -<T: Hashable, S: SequenceType where S.Generator.Element == T> (lhs: OrderedSet<T>, rhs: S) -> OrderedSet<T> {
+public func -<T: Hashable, S: Sequence> (lhs: OrderedSet<T>, rhs: S) -> OrderedSet<T> where S.Iterator.Element == T {
     let purgedSet = lhs
-    purgedSet.removeObjects(rhs)
+    purgedSet.remove(rhs)
     
     return purgedSet
 }
 
-public func -=<T: Hashable, S: SequenceType where S.Generator.Element == T> (inout lhs: OrderedSet<T>, rhs: S) {
-    lhs.removeObjects(rhs)
+public func -=<T: Hashable, S: Sequence> (lhs: inout OrderedSet<T>, rhs: S) where S.Iterator.Element == T {
+    lhs.remove(rhs)
 }
 
 extension OrderedSet: Equatable { }
@@ -416,7 +439,7 @@ public func ==<T: Hashable> (lhs: OrderedSet<T>, rhs: OrderedSet<T>) -> Bool {
 
 extension OrderedSet: CustomStringConvertible {
     public var description: String {
-        let children = map({ "\($0)" }).joinWithSeparator(", ")
+        let children = map({ "\($0)" }).joined(separator: ", ")
         return "OrderedSet (\(count) object(s)): [\(children)]"
     }
 }

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -252,8 +252,8 @@ open class OrderedSet<T: Hashable> {
      This method is a no-op if the index is the same that the object is currently at.
      This method will cause a fatal error if you attempt to move an object fro man index that is out of bounds
      or to an index that is out of bounds.
-     -parameter     index:      The index of the object to be moved.
-     -parameter     toIndex:    The index that the object should be moved to.
+     - parameter     index:      The index of the object to be moved.
+     - parameter     toIndex:    The index that the object should be moved to.
      */
     public func moveObject(at index: Index, to toIndex: Index) {
         if ((index < 0 || index >= count) || (toIndex < 0 || toIndex >= count)) {
@@ -319,13 +319,14 @@ open class OrderedSet<T: Hashable> {
             contents[sequencedContents[i].pointee] = i
         }
     }
+
+    /// Returns the last object in the set, or `nil` if the set is empty.
+    public var last: T? {
+        return sequencedContents.last?.pointee
+    }
 }
 
-extension OrderedSet: ExpressibleByArrayLiteral {
-
-
-
-}
+extension OrderedSet: ExpressibleByArrayLiteral { }
 
 extension OrderedSet where T: Comparable {}
 
@@ -356,24 +357,7 @@ extension OrderedSet: MutableCollection {
             sequencedContents[index].pointee = newValue
         }
     }
-}
 
-extension OrderedSet: BidirectionalCollection {
-
-    public func index(before i: Index) -> Int {
-        return sequencedContents.index(before: i)
-    }
-
-    public subscript(bounds: Range<Int>) -> BidirectionalSlice<OrderedSet<T>> {
-        get {
-            return BidirectionalSlice(base: self, bounds: bounds)
-        }
-        set {
-            for (index, _) in sequencedContents[bounds].enumerated() {
-                self[index] = newValue[index]
-            }
-        }
-    }
 }
 
 extension  OrderedSet: Sequence {

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -7,7 +7,7 @@
 //
 
 /// An ordered, unique collection of objects.
-open class OrderedSet<T: Hashable> {
+public class OrderedSet<T: Hashable> {
     fileprivate var contents = [T: Index]() // Needs to have a value of Index instead of Void for fast removals
     fileprivate var sequencedContents = Array<UnsafeMutablePointer<T>>()
     
@@ -370,7 +370,7 @@ extension  OrderedSet: Sequence {
 
 public struct OrderedSetGenerator<T: Hashable>: IteratorProtocol {
     public typealias Element = T
-    fileprivate var generator: IndexingIterator<Array<UnsafeMutablePointer<T>>>
+    private var generator: IndexingIterator<Array<UnsafeMutablePointer<T>>>
     
     public init(set: OrderedSet<T>) {
         generator = set.sequencedContents.makeIterator()


### PR DESCRIPTION
This PR upgrades the library to Swift 3 and adopts the new API design guidelines. 

Also, due to changes in collections in Swift 3, `OrderedSet` no longer gets the `last` freebie from protocol extensions, so a new `last` property has been added.
