### PR TITLE
Remove conformance to MutableCollection

### DIFF
--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -330,7 +330,11 @@ extension OrderedSet: ExpressibleByArrayLiteral { }
 
 extension OrderedSet where T: Comparable {}
 
-extension OrderedSet: MutableCollection {
+extension OrderedSet {
+    
+    public var count: Int {
+        return contents.count
+    }
 
     public func index(after i: Int) -> Int {
         return sequencedContents.index(after: i)


### PR DESCRIPTION
According to the documentation, a value stored into a subscript of a MutableCollection instance must subsequently be accessible at that same position. However, setting an OrderedSet subscript may result in a size change operation on the OrderedSet. For example, if we had 1,2,3 in the collection, and did set[2] = 1, the collection becomes 2,1. set[2] is now no longer accessible. There isn't a predictable/clean way to handle this case so I've opted to remove this conformance.

I've added what in the only method we used from MutableCollection as part of our API.

Based on comments in issue #9 
