### PR TITLE
add framework targets to enable use with Carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ xcuserdata
 *.pbxuser
 (*)/
 .DS_Store
+Carthage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 xcuserdata
+*.xctimeline
+*.xccheckout
+*.xcscmblueprint
+*.mode2v3
+*.pbxuser
+(*)/
+.DS_Store

--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 Weebly. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Framework/OrderedSet.h
+++ b/Framework/OrderedSet.h
@@ -1,0 +1,12 @@
+//
+//  OrderedSet.h
+//  OrderedSet
+//
+//  Created by Torsten Louland on 26/11/2016.
+//  Copyright © 2016 Weebly. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT double OrderedSetVersionNumber;
+FOUNDATION_EXPORT const unsigned char OrderedSetVersionString[];

--- a/Project Files/OrderedSet.xcodeproj/project.pbxproj
+++ b/Project Files/OrderedSet.xcodeproj/project.pbxproj
@@ -14,6 +14,10 @@
 		1ABC4FC61A5C966200DC4F4D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1ABC4FC51A5C966200DC4F4D /* Images.xcassets */; };
 		1ABC4FC91A5C966200DC4F4D /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1ABC4FC71A5C966200DC4F4D /* LaunchScreen.xib */; };
 		1ABC4FDF1A5C97F500DC4F4D /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABC4FDE1A5C97F500DC4F4D /* OrderedSet.swift */; };
+		AEBBEBB21DE9B371005525DE /* OrderedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBBEBB01DE9B371005525DE /* OrderedSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEBBEBB61DE9B4E5005525DE /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABC4FDE1A5C97F500DC4F4D /* OrderedSet.swift */; };
+		AEBBEBC41DE9B852005525DE /* OrderedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBBEBB01DE9B371005525DE /* OrderedSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEBBEBC51DE9B859005525DE /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABC4FDE1A5C97F500DC4F4D /* OrderedSet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +42,10 @@
 		1ABC4FCE1A5C966200DC4F4D /* OrderedSetTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OrderedSetTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1ABC4FD31A5C966200DC4F4D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1ABC4FDE1A5C97F500DC4F4D /* OrderedSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OrderedSet.swift; path = ../../Sources/OrderedSet.swift; sourceTree = "<group>"; };
+		AEBBEBAE1DE9B371005525DE /* OrderedSet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OrderedSet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AEBBEBB01DE9B371005525DE /* OrderedSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OrderedSet.h; sourceTree = "<group>"; };
+		AEBBEBB11DE9B371005525DE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AEBBEBBC1DE9B78F005525DE /* OrderedSet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OrderedSet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +63,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AEBBEBAA1DE9B371005525DE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AEBBEBB81DE9B78F005525DE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -63,6 +85,7 @@
 			children = (
 				1ABC4FB91A5C966200DC4F4D /* OrderedSet */,
 				1ABC4FD11A5C966200DC4F4D /* OrderedSetTests */,
+				AEBBEBAF1DE9B371005525DE /* Framework Support */,
 				1ABC4FB81A5C966200DC4F4D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -72,6 +95,8 @@
 			children = (
 				1ABC4FB71A5C966200DC4F4D /* OrderedSet.app */,
 				1ABC4FCE1A5C966200DC4F4D /* OrderedSetTests.xctest */,
+				AEBBEBAE1DE9B371005525DE /* OrderedSet.framework */,
+				AEBBEBBC1DE9B78F005525DE /* OrderedSet.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -115,7 +140,36 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		AEBBEBAF1DE9B371005525DE /* Framework Support */ = {
+			isa = PBXGroup;
+			children = (
+				AEBBEBB01DE9B371005525DE /* OrderedSet.h */,
+				AEBBEBB11DE9B371005525DE /* Info.plist */,
+			);
+			name = "Framework Support";
+			path = ../Framework;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		AEBBEBAB1DE9B371005525DE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AEBBEBB21DE9B371005525DE /* OrderedSet.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AEBBEBB91DE9B78F005525DE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AEBBEBC41DE9B852005525DE /* OrderedSet.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		1ABC4FB61A5C966200DC4F4D /* OrderedSet */ = {
@@ -153,6 +207,42 @@
 			productReference = 1ABC4FCE1A5C966200DC4F4D /* OrderedSetTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		AEBBEBAD1DE9B371005525DE /* OrderedSet-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AEBBEBB51DE9B371005525DE /* Build configuration list for PBXNativeTarget "OrderedSet-iOS" */;
+			buildPhases = (
+				AEBBEBA91DE9B371005525DE /* Sources */,
+				AEBBEBAA1DE9B371005525DE /* Frameworks */,
+				AEBBEBAB1DE9B371005525DE /* Headers */,
+				AEBBEBAC1DE9B371005525DE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "OrderedSet-iOS";
+			productName = "OrderedSet-iOS";
+			productReference = AEBBEBAE1DE9B371005525DE /* OrderedSet.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		AEBBEBBB1DE9B78F005525DE /* OrderedSet-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AEBBEBC11DE9B78F005525DE /* Build configuration list for PBXNativeTarget "OrderedSet-macOS" */;
+			buildPhases = (
+				AEBBEBB71DE9B78F005525DE /* Sources */,
+				AEBBEBB81DE9B78F005525DE /* Frameworks */,
+				AEBBEBB91DE9B78F005525DE /* Headers */,
+				AEBBEBBA1DE9B78F005525DE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "OrderedSet-macOS";
+			productName = "OrderedSet-macOS";
+			productReference = AEBBEBBC1DE9B78F005525DE /* OrderedSet.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -172,6 +262,14 @@
 						LastSwiftMigration = 0800;
 						TestTargetID = 1ABC4FB61A5C966200DC4F4D;
 					};
+					AEBBEBAD1DE9B371005525DE = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
+					AEBBEBBB1DE9B78F005525DE = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 1ABC4FB21A5C966200DC4F4D /* Build configuration list for PBXProject "OrderedSet" */;
@@ -189,6 +287,8 @@
 			targets = (
 				1ABC4FB61A5C966200DC4F4D /* OrderedSet */,
 				1ABC4FCD1A5C966200DC4F4D /* OrderedSetTests */,
+				AEBBEBAD1DE9B371005525DE /* OrderedSet-iOS */,
+				AEBBEBBB1DE9B78F005525DE /* OrderedSet-macOS */,
 			);
 		};
 /* End PBXProject section */
@@ -205,6 +305,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		1ABC4FCC1A5C966200DC4F4D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AEBBEBAC1DE9B371005525DE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AEBBEBBA1DE9B78F005525DE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -229,6 +343,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A15ED131A5DC30B00D40BDD /* OrderedSet_Tests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AEBBEBA91DE9B371005525DE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AEBBEBB61DE9B4E5005525DE /* OrderedSet.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AEBBEBB71DE9B78F005525DE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AEBBEBC51DE9B859005525DE /* OrderedSet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -281,7 +411,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -327,7 +456,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -351,6 +479,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = OrderedSet/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Weebly.$(PRODUCT_NAME:rfc1034identifier)";
@@ -363,6 +492,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = OrderedSet/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Weebly.$(PRODUCT_NAME:rfc1034identifier)";
@@ -409,6 +539,120 @@
 			};
 			name = Release;
 		};
+		AEBBEBB31DE9B371005525DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ../Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Weebly.OrderedSet;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		AEBBEBB41DE9B371005525DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ../Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Weebly.OrderedSet;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		AEBBEBC21DE9B78F005525DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = ../Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Weebly.OrderedSet;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		AEBBEBC31DE9B78F005525DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = ../Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Weebly.OrderedSet;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -438,6 +682,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		AEBBEBB51DE9B371005525DE /* Build configuration list for PBXNativeTarget "OrderedSet-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AEBBEBB31DE9B371005525DE /* Debug */,
+				AEBBEBB41DE9B371005525DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		AEBBEBC11DE9B78F005525DE /* Build configuration list for PBXNativeTarget "OrderedSet-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AEBBEBC21DE9B78F005525DE /* Debug */,
+				AEBBEBC31DE9B78F005525DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/README.md
+++ b/README.md
@@ -26,11 +26,19 @@ Be sure to check out the unit tests to see all the different ways to interact wi
 
 # Installation
 
-OrderedSet is a single Swift file in the Sources directory. You can copy that file into your project, or use CocoaPods by adding the following line to your Podfile:
+OrderedSet is a single Swift file in the Sources directory. You can copy that file into your project, or use via CocoaPods by adding the following line to your Podfile:
 
 ```ruby
 pod 'OrderedSet', '2.0'
 ```
+
+or use via Carthage by adding
+
+```
+github "Weebly/OrderedSet"
+```
+
+to your Cartfile and embedding the OrderedSet.framework in your app.
 
 And then add the following import where you want to use OrderedSet:
 


### PR DESCRIPTION
Hi,

I added targets to build iOS and macOS frameworks so that OrderedSet can be used via Carthage. Also important to ignore Carthage/ subdirectory. Only app target is now code signed; frameworks don't need this when embedded. Some other fairly standard additions to .gitignore as well. 

These new targets shouldn't affect your podspec, but you might want to check.

If you accept the pull, please could you also tag a new version (2.0.5), otherwise Carthage will only pull the previous version and won't get the frameworks.

Cheers!