### PR TITLE
add license terms to source file

### DIFF
--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -1,10 +1,5 @@
-//
-//  OrderedSet.swift
-//  Weebly
-//
-//  Created by James Richard on 10/22/14.
-//  Copyright (c) 2014 Weebly.
-//
+//  Copyright (c) 2014 James Richard. 
+//  Distributed under the MIT License (http://opensource.org/licenses/MIT).
 
 /// An ordered, unique collection of objects.
 public class OrderedSet<T: Hashable> {


### PR DESCRIPTION
Since the overhead of checking out the project as a framework doesn't pay off, this change adds minimum license info to the file that people will copy into their code.