### PR TITLE
Make OrderedSet copy-on-write to avoid crashes and spookiness

### DIFF
--- a/Project Files/OrderedSetTests/OrderedSet_Tests.swift
+++ b/Project Files/OrderedSetTests/OrderedSet_Tests.swift
@@ -76,6 +76,13 @@ class OrderedSet_Tests: XCTestCase {
         XCTAssertEqual(contents[0], 0)
         XCTAssertEqual(contents[1], 2)
     }
+
+    func testSubscriptAssignObjectAtIndex_doesNotAffectOtherSet() {
+        let other: OrderedSet<String> = ["One"]
+        var subject = other
+        subject[0] = "Two"
+        XCTAssertNotEqual(subject, other)
+    }
     
     // MARK: Contains
 

--- a/Project Files/OrderedSetTests/OrderedSet_Tests.swift
+++ b/Project Files/OrderedSetTests/OrderedSet_Tests.swift
@@ -186,6 +186,13 @@ class OrderedSet_Tests: XCTestCase {
         let indexes = subject.remove(["Two", "Three", "Six"])
         XCTAssertEqual(indexes, [1, 2])
     }
+
+    func testRemoveObjects__whenRemovingSameObjectFromTwoSets_doesNotCrash() {
+        var original = OrderedSet<String>(sequence: ["One"])
+        var subject = original
+        original.remove("One")
+        subject.remove("One")
+    }
     
     // MARK: Remove Object At Index
     

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -40,7 +40,14 @@ public struct OrderedSet<T: Hashable> {
         }
 
         func copy() -> SequencedContents {
-            return self
+            let copy = SequencedContents()
+            copy.pointers.reserveCapacity(pointers.count)
+            for p in pointers {
+                let newP = UnsafeMutablePointer<T>.allocate(capacity: 1)
+                newP.initialize(from: p, count: 1)
+                copy.pointers.append(newP)
+            }
+            return copy
         }
     }
     
@@ -384,7 +391,7 @@ public struct OrderedSet<T: Hashable> {
      same references to the previous. This is NOT a deep copy or a clone!
      */
     public func copy() -> OrderedSet<T> {
-        return OrderedSet<T>(sequence: self)
+        return self
     }
     
     /// Returns the last object in the set, or `nil` if the set is empty.


### PR DESCRIPTION
Hello! I'm wondering if making `OrderedSet` into a proper copy-on-write type is something y'all would consider, and it's totally ok if the answer is "no"!

We ran into a double-free crash removing the same element from two `OrderedSet`s where the second `OrderedSet` was made by referring to the first (`var newSet = oldSet`). See test `testRemoveObjects__whenRemovingSameObjectFromTwoSets_doesNotCrash()` in this PR. The underlying issue is that each `OrderedSet` has an array of pointers that point to the same memory addresses, so the second `OrderedSet` to deallocate that memory will crash.

At this point, we noticed the `copy()` method :) That lets us avoid crashing. But it occurred to me that if one `OrderedSet` can cause another to crash, one `OrderedSet` can probably mess with another in other fun ways. This is test `testSubscriptAssignObjectAtIndex_doesNotAffectOtherSet()`, where `newSet[0] = "foo"` modifies `oldSet`.

As a quick fix, I moved `sequencedContents` into a reference type and got `OrderedSet` to copy it whenever it's not uniquely referenced. This fixes the issues I found above, and it obviates the `copy()` method.

If making `OrderedSet` copy-on-write like this seems sensible, I'm more than happy to reformat this PR as needed. The main downside I can think of is possibly slower performance, but I admit I have not even attempted to do benchmarks. And it might be cleaner to move most of the logic, as well as the `contents` dictionary, into the storage class? I'm happy to do that too.

If y'all aren't interested in this change to `OrderedSet`, that's totally fair. I don't have any great suggestions for avoiding the double-free crash though, beyond wrapping each pointer in a reference type and ensuring deallocation only happens once. It might be worth considering whether to change `OrderedSet` to a reference type (i.e. `class OrderedSet`) and/or to add some documentation that sets don't work the same way as built-in collection types like `Array` and `Dictionary`; I suspect we're not the first and won't be the last to have the wrong expectation.

Thanks!