### PR TITLE
Add `removeAllObject(where:)` function in ordered set

### DIFF
--- a/Project Files/OrderedSetTests/OrderedSet_Tests.swift
+++ b/Project Files/OrderedSetTests/OrderedSet_Tests.swift
@@ -220,6 +220,12 @@ class OrderedSet_Tests: XCTestCase {
     
     // MARK: Remove All Objects
     
+    func testRemoveAllObjects_removesAllObjectsThatSatisfyGivenPredicate() {
+        var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
+        let indexes = subject.removeAllObjects(where: { $0.hasPrefix("T") })
+        XCTAssertEqual(indexes, [1, 2])
+    }
+    
     func testRemoveAllObjects_removesAllObjects() {
         var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
         subject.removeAllObjects()

--- a/Project Files/OrderedSetTests/OrderedSet_Tests.swift
+++ b/Project Files/OrderedSetTests/OrderedSet_Tests.swift
@@ -222,8 +222,10 @@ class OrderedSet_Tests: XCTestCase {
     
     func testRemoveAllObjects_removesAllObjectsThatSatisfyGivenPredicate() {
         var subject = OrderedSet<String>(sequence: ["One", "Two", "Three"])
-        let indexes = subject.removeAllObjects(where: { $0.hasPrefix("T") })
-        XCTAssertEqual(indexes, [1, 2])
+        let removedObjects = subject.removeAllObjects(where: { $0.hasPrefix("T") })
+        let expected: OrderedSet<String> = ["One"]
+        XCTAssertEqual(subject, expected)
+        XCTAssertEqual(removedObjects, ["Two", "Three"])
     }
     
     func testRemoveAllObjects_removesAllObjects() {

--- a/Project Files/OrderedSetTests/OrderedSet_Tests.swift
+++ b/Project Files/OrderedSetTests/OrderedSet_Tests.swift
@@ -225,7 +225,8 @@ class OrderedSet_Tests: XCTestCase {
         let removedObjects = subject.removeAllObjects(where: { $0.hasPrefix("T") })
         let expected: OrderedSet<String> = ["One"]
         XCTAssertEqual(subject, expected)
-        XCTAssertEqual(removedObjects, ["Two", "Three"])
+        let expectedRemovedObjects: OrderedSet<String> = ["Two", "Three"]
+        XCTAssertEqual(removedObjects, expectedRemovedObjects)
     }
     
     func testRemoveAllObjects_removesAllObjects() {

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -200,6 +200,27 @@ public struct OrderedSet<T: Hashable> {
     }
     
     /**
+     Removes all objects that satisfy the given predicate in the ordered set.
+     - parameter    shouldBeRemoved: A closure that takes an object in the ordered set as its argument and returns a Boolean value indicating whether the object should be removed from the ordered set.
+     - returns: A collection of the former index positions of the objects. An index position is not provided for objects that were not found.
+    */
+    @discardableResult
+    public mutating func removeAllObjects(where shuldBeRemoved: (T) -> Bool) -> [Index] {
+        
+        let shouldBeRemovedContents = contents.filter { value, _ in
+            shuldBeRemoved(value)
+        }
+        
+        var indexes = [Index]()
+        var gen = shouldBeRemovedContents.makeIterator()
+        while let (value, index): (T, Index) = gen.next() {
+            remove(value)
+            indexes.append(index)
+        }
+        return indexes
+    }
+    
+    /**
      Removes all objects in the ordered set.
      */
     public mutating func removeAllObjects() {

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -202,12 +202,12 @@ public struct OrderedSet<T: Hashable> {
     /**
      Removes all objects that satisfy the given predicate in the ordered set.
      - parameter    shouldBeRemoved: A closure that takes an object in the ordered set as its argument and returns a Boolean value indicating whether the object should be removed from the ordered set.
-     - returns: The objects to be removed in ordered set.
+     - returns: The objects that were removed from the ordered set.
     */
     @discardableResult
-    public mutating func removeAllObjects(where shouldBeRemoved: (T) -> Bool) -> [T] {
+    public mutating func removeAllObjects(where shouldBeRemoved: (T) -> Bool) -> OrderedSet<T> {
         
-        var removedObjects = [T]()
+        var removedObjects = OrderedSet<T>()
         var pointers = sequencedContents.pointers.makeIterator()
         while let object = pointers.next()?.pointee {
             if shouldBeRemoved(object) {

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -202,22 +202,20 @@ public struct OrderedSet<T: Hashable> {
     /**
      Removes all objects that satisfy the given predicate in the ordered set.
      - parameter    shouldBeRemoved: A closure that takes an object in the ordered set as its argument and returns a Boolean value indicating whether the object should be removed from the ordered set.
-     - returns: A collection of the former index positions of the objects. An index position is not provided for objects that were not found.
+     - returns: The objects to be removed in ordered set.
     */
     @discardableResult
-    public mutating func removeAllObjects(where shuldBeRemoved: (T) -> Bool) -> [Index] {
+    public mutating func removeAllObjects(where shouldBeRemoved: (T) -> Bool) -> [T] {
         
-        let shouldBeRemovedContents = contents.filter { value, _ in
-            shuldBeRemoved(value)
+        var removedObjects = [T]()
+        var pointers = sequencedContents.pointers.makeIterator()
+        while let object = pointers.next()?.pointee {
+            if shouldBeRemoved(object) {
+                remove(object)
+                removedObjects.append(object)
+            }
         }
-        
-        var indexes = [Index]()
-        var gen = shouldBeRemovedContents.makeIterator()
-        while let (value, index): (T, Index) = gen.next() {
-            remove(value)
-            indexes.append(index)
-        }
-        return indexes
+        return removedObjects
     }
     
     /**


### PR DESCRIPTION
Hi~ 👋 i want to add `removeAllObject(where:)` function in ordered set

`removeAllObject(where:)` function has simple logic and powerful  
we can use it when want to remove all objects that satisfy the given predicate in the ordered set.  
like [Swift.Array.removeAllObject](https://developer.apple.com/documentation/swift/array/3017530-removeall)

i can't waiting your good feedback~😆 thanks